### PR TITLE
Removing includes for amounts because it is very slow

### DIFF
--- a/app/models/plutus/account.rb
+++ b/app/models/plutus/account.rb
@@ -41,8 +41,6 @@ module Plutus
 
     belongs_to :accountable, polymorphic: true, optional: true
 
-    default_scope { includes [:credit_amounts, :debit_amounts] }
-
     validates_presence_of :type
 
     if Plutus.enable_tenancy

--- a/app/models/plutus/expense.rb
+++ b/app/models/plutus/expense.rb
@@ -52,9 +52,5 @@ module Plutus
     def self.balance(options={})
       super
     end
-
-    def balance
-      Money.from_amount balance
-    end
   end
 end

--- a/app/models/plutus/revenue.rb
+++ b/app/models/plutus/revenue.rb
@@ -52,9 +52,5 @@ module Plutus
     def self.balance(options={})
       super
     end
-
-    def balance
-      Money.from_amount balance
-    end
   end
 end


### PR DESCRIPTION
It is really slow if you eager load all of the amounts on a `Plutus::Entry`.  

I'm removing those includes so that it goes faster.